### PR TITLE
Support node v10 based docker images for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gasbuddy/node-app:14-production
+FROM gasbuddy/node-app:10-production
 
 ARG NODE_ENV_ARG=production
 


### PR DESCRIPTION
I WONT BE MERGING THIS PR TO MAIN.

The reason for this PR is to create a tag with node-v10 to support GasBuddy projects needing to run on Node v10. We simply don't support anything less than node v12 as of now for build-push-ecr and `gh-ecr-push`.