### PR TITLE
Update action.yml for CEGBDO-3002

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
 
     - name: Push to ECR
       id: ecr
-      uses: gas-buddy/gh-ecr-push@v1.3.6
+      uses: gas-buddy/gh-ecr-push@v2.0.2
       with:
         access-key-id: ${{ inputs.aws-access-key-id }}
         secret-access-key: ${{ inputs.aws-secret-access-key }}


### PR DESCRIPTION
`gh-ecr-push` is synced with upstream repo, so taking recent version.